### PR TITLE
Allow custom sf binary download

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,5 @@
-**/.git
-**/.github
-**/.gitignore
-**/.vscode
-**/.editorconfig
+**/.*
 **/*venv*
 **/__pycache__
-**/.dockerignore
 **/Dockerfile
 **/docker-compose*

--- a/.gitignore
+++ b/.gitignore
@@ -130,4 +130,5 @@ dmypy.json
 
 # IDE settings
 .vscode/
+.idea/
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,19 @@ RUN apt-get update -y && \
     apt-get upgrade -y
 
 # Build stockfish binary
+ARG STOCKFISH_BIN_URL
 WORKDIR /tmp
-RUN wget https://github.com/official-stockfish/Stockfish/archive/refs/tags/sf_15.zip && \
-    unzip sf_15.zip && \
-    cd Stockfish-sf_15/src && \
-    make build ARCH=x86-64-modern && \
-    cp stockfish /usr/local/bin/stockfish && \
-    rm -rf *sf_15*
+RUN if [ -z ${STOCKFISH_BIN_URL} ]; then \
+        wget https://github.com/official-stockfish/Stockfish/archive/refs/tags/sf_15.zip && \
+        unzip sf_15.zip && \
+        cd Stockfish-sf_15/src && \
+        make build ARCH=x86-64-modern && \
+        cp stockfish /usr/local/bin/stockfish && \
+        rm -rf *sf_15*; \
+    else \
+        wget ${STOCKFISH_BIN_URL} -O /usr/local/bin/stockfish && \
+        chmod +x /usr/local/bin/stockfish; \
+    fi
 
 # Copy files for websocket server
 WORKDIR /stockfish-socket-server

--- a/run.py
+++ b/run.py
@@ -3,6 +3,12 @@ from pathlib import Path
 from stockfish_socket_server import app
 
 def create_app(stockfish_path, debug_mode=False):
+    """
+    Create the server Flask instance.
+    :param stockfish_path: Path to the stockfish binary
+    :param debug_mode: Boolean to enable Flask debug mode
+    :return: Flask app instance
+    """
     app.config['DEBUG'] = debug_mode
     app.config['stockfish_path'] = stockfish_path
 

--- a/stockfish_socket_server/__init__.py
+++ b/stockfish_socket_server/__init__.py
@@ -7,6 +7,11 @@ socket = Sock(app)
 
 @socket.route('/senduci')
 def process_uci(ws):
+    """
+    Route for sending and handling uci engine commands
+    :param ws: Websocket connection
+    :return: None
+    """
     stockfish_socket_emitter = StockfishSocketEmitter(
         stockfish_path=app.config.get('stockfish_path')
     )

--- a/stockfish_socket_server/models.py
+++ b/stockfish_socket_server/models.py
@@ -4,6 +4,9 @@ from threading import Thread, Event
 
 
 class StockfishSocketEmitter:
+    """
+    Emitter class to handle messages and send the engine output to the client.
+    """
     def __init__(self, stockfish_path):
         if not Path(stockfish_path).exists():
             raise ValueError(f'No executable found at: {stockfish_path}')
@@ -14,6 +17,10 @@ class StockfishSocketEmitter:
         self.stop_signal = Event()
 
     def _create_stockfish_process(self):
+        """
+        Create the stockfish process
+        :return: None
+        """
         if not self.stockfish_process:
             self.stockfish_process = subprocess.Popen(
                 self.stockfish_path,
@@ -24,10 +31,21 @@ class StockfishSocketEmitter:
             )
 
     def send_uci(self, command):
+        """
+        Send the uci command to the engine
+        :param command: uci command
+        :return: None
+        """
         self.stockfish_process.stdin.write(f'{command}\n')
         self.stockfish_process.stdin.flush()
 
     def emit_stockfish_stdout(self, ws, stop_signal):
+        """
+        Send the engine stdout to the client; close client connection on quit command
+        :param ws: Websocket connection
+        :param stop_signal: Event to signal stop requested and close client connection
+        :return: None
+        """
         while not stop_signal.wait(0):
             if not self.stockfish_process.stdout:
                 raise BrokenPipeError()
@@ -39,6 +57,11 @@ class StockfishSocketEmitter:
         ws.close(message='quit_command_received')
 
     def start(self, ws):
+        """
+        Start the Websocket server
+        :param ws: Websocket connection
+        :return: None
+        """
         self._create_stockfish_process()
         self.emitter_thread = Thread(
             target=self.emit_stockfish_stdout,
@@ -48,6 +71,10 @@ class StockfishSocketEmitter:
         self.emitter_thread.start()
 
     def stop(self):
+        """
+        Stop the Websocket server, and kill the stockfish process
+        :return: None
+        """
         if self.stockfish_process.poll() is None:
             self.stop_signal.set()
             self.send_uci('quit')

--- a/tests/test_server_connect.py
+++ b/tests/test_server_connect.py
@@ -39,3 +39,4 @@ def test_server_connect(app_instance):
 
     # Disconnect client
     ws.close()
+    app_instance.join(timeout=1)


### PR DESCRIPTION
Allow custom stockfish binary to be downloaded using `--build-arg` with `STOCKFISH_BIN_URL` variable.